### PR TITLE
Frozen `LJHFile` object

### DIFF
--- a/examples/bessy_20240727.py
+++ b/examples/bessy_20240727.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.13.3"
+__generated_with = "0.14.10"
 app = marimo.App(width="medium", app_title="MOSS intro")
 
 
@@ -8,13 +8,13 @@ app = marimo.App(width="medium", app_title="MOSS intro")
 def _(mo):
     mo.md(
         """
-        #MOSS internals introdution
-        MOSS is the Microcalorimeter Online Spectral Software, a replacement for MASS. MOSS support many algorithms for pulse filtering, calibration, and corrections. MOSS is built on modern open source data science software, including pola.rs and marimo. MOSS supports some key features that MASS struggled with including:
+    #MOSS internals introdution
+    MOSS is the Microcalorimeter Online Spectral Software, a replacement for MASS. MOSS support many algorithms for pulse filtering, calibration, and corrections. MOSS is built on modern open source data science software, including pola.rs and marimo. MOSS supports some key features that MASS struggled with including:
 
-          * consecutive data set analysis
-          * online (aka realtime) analysis
-          * easily supporting different analysis chains
-        """
+      * consecutive data set analysis
+      * online (aka realtime) analysis
+      * easily supporting different analysis chains
+    """
     )
     return
 
@@ -39,9 +39,9 @@ def _():
 def _(mo):
     mo.md(
         """
-        # Load data
-        Here we load the data, then we explore the internals a bit to show how MOSS is built.
-        """
+    # Load data
+    Here we load the data, then we explore the internals a bit to show how MOSS is built.
+    """
     )
     return
 
@@ -60,13 +60,13 @@ def _(moss, pulsedata):
 def _(mo):
     mo.md(
         """
-        # basic analysis
-        The variables `data` is the conventional name for a `Channels` object. It contains a list of `Channel` objects, conventinally assigned to a variable `ch` when accessed individualy. One `Channel` represents a single pixel, whiles a `Channels` is a collection of pixels, like a whole array.
+    # basic analysis
+    The variables `data` is the conventional name for a `Channels` object. It contains a list of `Channel` objects, conventinally assigned to a variable `ch` when accessed individualy. One `Channel` represents a single pixel, whiles a `Channels` is a collection of pixels, like a whole array.
 
-        The data tends to consist of pulse shapes (arrays of length 100 to 1000 in general) and per pulse quantities, such as the pretrigger mean. These data are stored internally as pola.rs `DataFrame` objects.
+    The data tends to consist of pulse shapes (arrays of length 100 to 1000 in general) and per pulse quantities, such as the pretrigger mean. These data are stored internally as pola.rs `DataFrame` objects.
 
-        The next cell shows a basic analysis on multiple channels. The function `data.transform_channels` takes a one argument function, where the one argument is a `Channel` and the function returns a `Channel`, `data.transform_channels` returns a `Channels`. There is no mutation, and we can't re-use variable names in a reactive notebook, so we store the result in a new variable `data2`.
-        """
+    The next cell shows a basic analysis on multiple channels. The function `data.transform_channels` takes a one argument function, where the one argument is a `Channel` and the function returns a `Channel`, `data.transform_channels` returns a `Channels`. There is no mutation, and we can't re-use variable names in a reactive notebook, so we store the result in a new variable `data2`.
+    """
     )
     return
 

--- a/examples/bessy_20240727.py
+++ b/examples/bessy_20240727.py
@@ -1,5 +1,3 @@
-
-
 import marimo
 
 __generated_with = "0.13.3"

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -9,6 +9,7 @@ def test_ljh_mnkalpha():
     from . import parquet_after_ljh_mnkalpha as notebook2
     notebook2.app.run()
 
+
 def test_off_ebit():
     from . import off_ebit as notebook
     notebook.app.run()
@@ -18,6 +19,7 @@ def test_broken_notebook():
     from . import broken_notebook as notebook
     with pytest.raises(Exception):
         notebook.app.run()
+
 
 def test_ebit_july2024_from_off():
     from . import ebit_july2024_from_off as notebook

--- a/moss/channel.py
+++ b/moss/channel.py
@@ -537,7 +537,7 @@ class Channel:
             noise_channel = None
         else:
             noise_channel = moss.NoiseChannel.from_ljh(noise_path)
-        ljh = moss.LJHFile(path)
+        ljh = moss.LJHFile.open(path)
         df, header_df = ljh.to_polars(keep_posix_usec)
         header = moss.ChannelHeader.from_ljh_header_df(header_df)
         channel = moss.Channel(df, header=header, noise=noise_channel)

--- a/moss/channel.py
+++ b/moss/channel.py
@@ -573,8 +573,8 @@ class Channel:
     def with_experiment_state_df(self, df_es, force_timestamp_monotonic=False) -> "Channel":
         if not self.df["timestamp"].is_sorted():
             df = self.df.select(pl.col("timestamp").cum_max().alias("timestamp")).with_columns(self.df.select(pl.exclude("timestamp")))
-            print("WARNING: in with_experiment_state_df, timestamp is not monotonic, forcing it to be")
-            print("This is likely a BUG in DASTARD.")
+            # print("WARNING: in with_experiment_state_df, timestamp is not monotonic, forcing it to be")
+            # print("This is likely a BUG in DASTARD.")
         else:
             df = self.df
         df2 = df.join_asof(df_es, on="timestamp", strategy="backward")
@@ -640,7 +640,7 @@ class Channel:
 
     def as_bad(self, error_type, error_msg, backtrace):
         return BadChannel(self, error_type, error_msg, backtrace)
-    
+
     def save_steps(self, filename):
         steps = {self.header.ch_num: self.steps[:]}
         moss.misc.pickle_object(steps, filename)

--- a/moss/ljhfiles.py
+++ b/moss/ljhfiles.py
@@ -1,42 +1,63 @@
+from dataclasses import dataclass, replace
+from typing import Optional, ClassVar, Self, Tuple
+import numpy.typing as npt
+import os
 import numpy as np
 import polars as pl
-import os
-import collections
 
 
-class LJHFile():
-    TOO_LONG_HEADER = 100
+@dataclass(frozen=True)
+class LJHFile:
+    filename: str
+    dtype: np.dtype
+    npulses: int
+    timebase: float
+    nsamples: int
+    npresamples: int
+    client: str
+    header: dict
+    header_string: str
+    header_size: int
+    binary_size: int
+    _mmap: np.memmap
+    first_pulse: int = 0
+    max_pulses: Optional[int] = None
+    OVERLONG_HEADER: ClassVar[int] = 100
 
-    def __init__(self, filename, _limit_pulses=None):
-        self.filename = filename
-        self.__read_header(self.filename)
-        self.dtype = np.dtype([('rowcount', np.int64),
-                               ('posix_usec', np.int64),
-                               ('data', np.uint16, self.nSamples)])
-        self.__open_binary(0, _limit_pulses)
+    @classmethod
+    def open(cls, filename: str, first_pulse: int = 0, max_pulses: Optional[int] = None) -> "LJHFile":
+        header_dict, header_string, header_size = cls.read_header(filename)
+        nsamples = header_dict["Total Samples"]
+        timebase = header_dict["Timebase"]
+        nsamples = header_dict["Total Samples"]
+        npresamples = header_dict["Presamples"]
+        client = header_dict.get("Software Version", "UNKNOWN")
+        dtype = np.dtype([('rowcount', np.int64),
+                          ('posix_usec', np.int64),
+                          ('data', np.uint16, nsamples)])
+        pulse_size_bytes = dtype.itemsize
+        binary_size = os.path.getsize(filename) - header_size
 
-    def __open_binary(self, pulsesToSkip: int, _limit_pulses=None):
-        self.binary_size = os.path.getsize(self.filename) - self.header_size
-        full_nPulses = self.binary_size // self.pulse_size_bytes
-        self.nPulses = full_nPulses - pulsesToSkip
-        if _limit_pulses is not None:
-            # this is used to demo the process of watching an
-            # ljh file grow over time
-            self.nPulses = min(_limit_pulses, self.nPulses)
-        offset = self.header_size + pulsesToSkip * self.pulse_size_bytes
-        self._mmap = np.memmap(self.filename, self.dtype, mode="r",
-                               offset=offset, shape=(self.nPulses,))
-        self._cache_i = -1
-        self._cache_data = None
+        # Fix long-standing bug in LJH files made by MATTER or XCALDAQ_client:
+        # It adds 3 to the "true value" of nPresamples. For now, assume that only
+        # DASTARD clients have this figure correct.
+        if "DASTARD" not in client:
+            npresamples += 3
 
-    def reopen_binary(self, pulsesToSkip: int, _limit_pulses=None):
-        try:
-            del self._mmap
-        except AttributeError:
-            pass
-        self.__open_binary(pulsesToSkip, _limit_pulses)
+        full_npulses = binary_size // pulse_size_bytes
+        npulses = full_npulses - first_pulse
+        if max_pulses is not None:
+            npulses = min(max_pulses, npulses)
+        offset = header_size + first_pulse * pulse_size_bytes
+        mmap = np.memmap(filename, dtype, mode="r",
+                         offset=offset, shape=(npulses,))
 
-    def __read_header(self, filename):
+        return LJHFile(filename, dtype, npulses, timebase, nsamples, npresamples, client,
+                       header_dict, header_string, header_size, binary_size,
+                       mmap, first_pulse, max_pulses)
+
+    @classmethod
+    def read_header(cls, filename: str) -> Tuple[dict, str, int]:
         """Read in the text header of an LJH file.
 
         On success, several attributes will be set: self.timebase, .nSamples,
@@ -46,101 +67,74 @@ class LJHFile():
             filename: path to the file to be opened.
         """
         # parse header into a dictionary
-        header_dict = collections.OrderedDict()
+        header_dict = {}
         with open(filename, "rb") as fp:
             i = 0
+            lines = []
             while True:
+                line = fp.readline().decode()
+                lines.append(line)
                 i += 1
-                line = fp.readline()
-                if line.startswith(b"#End of Header"):
+                if line.startswith("#End of Header"):
                     break
-                elif line == b"":
+                elif line == "":
                     raise Exception("reached EOF before #End of Header")
-                elif i > self.TOO_LONG_HEADER:
-                    raise IOError("header is too long--seems not to contain '#End of Header'\n"
-                                  + "in file %s" % filename)
-                elif b":" in line:
-                    a, b = line.split(b":", 1)  # maxsplits=1, py27 doesnt support keyword
+                elif i > cls.OVERLONG_HEADER:
+                    raise Exception(f"header is too long--seems not to contain '#End of Header'\nin file {filename}")
+                # ignore lines without ":"
+                elif ":" in line:
+                    a, b = line.split(":", maxsplit=1)
                     a = a.strip()
                     b = b.strip()
-                    a = a.decode()
-                    b = b.decode()
-                    if a in header_dict and a != "Dummy":
-                        print("LJHFile.__read_header: repeated header entry {}".format(a))
                     header_dict[a] = b
-                else:
-                    continue  # ignore lines without ":"
-            self.header_size = fp.tell()
-            fp.seek(0)
-            self.header_str = fp.read(self.header_size)
+            header_size = fp.tell()
+        header_string = "".join(lines)
 
-        # extract required values from header_dict
-        # use header_dict.get for default values
+        # Convert values from header_dict into numeric types, when appropriate
         header_dict["Filename"] = filename
-        header_dict["Channel"] = int(header_dict["Channel"])
-        header_dict["Timebase"] = float(header_dict["Timebase"])
-        self.timebase = header_dict["Timebase"]
-        header_dict["Total Samples"] = int(header_dict["Total Samples"])
-        self.nSamples = header_dict["Total Samples"]
-        header_dict["Presamples"] = int(header_dict["Presamples"])
-        self.nPresamples = header_dict["Presamples"]
-        # column number and row number have entries like "Column number (from 0-0 inclusive)"
-        row_number_k = [k for k in header_dict.keys() if k.startswith("Row number")]
-        if len(row_number_k) > 0:
-            self.row_number = int(header_dict[row_number_k[0]])
-        col_number_k = [k for k in header_dict.keys() if k.startswith("Column number")]
-        if len(col_number_k) > 0:
-            self.row_number = int(header_dict[col_number_k[0]])
-        self.client = header_dict.get("Software Version", "UNKNOWN")
-        header_dict["Number of Columns"] = int(header_dict.get("Number of columns", -1))
-        self.number_of_columns = header_dict["Number of Columns"]
-        header_dict["Number of rows"] = int(header_dict.get("Number of rows", -1))
-        self.number_of_rows = header_dict["Number of rows"]
-        self.timestamp_offset = float(header_dict.get("Timestamp offset (s)", "-1"))
-        self.version_str = header_dict['Save File Format Version']
+        for (name, datatype) in {
+            ("Channel", int),
+            ("Timebase", float),
+            ("Total Samples", int),
+            ("Presamples", int),
+            ("Number of columns", int),
+            ("Number of rows", int),
+        }:
+            header_dict[name] = datatype(header_dict.get(name, -1))
+        return header_dict, header_string, header_size
 
-        # if Version(self.version_str.decode()) >= Version("2.2.0"):
-        self.pulse_size_bytes = (16 + 2 * self.nSamples)  # dont bother with old ljh
-        # else:
-        #     self.pulse_size_bytes = (6 + 2 * self.nSamples)
-        self.binary_size = os.path.getsize(filename) - self.header_size
-        self.header_dict = header_dict
-        self.nPulses = self.binary_size // self.pulse_size_bytes
-        # Fix long-standing bug in LJH files made by MATTER or XCALDAQ_client:
-        # It adds 3 to the "true value" of nPresamples. For now, assume that only
-        # DASTARD clients have this figure correct.
-        if "DASTARD" not in self.client:
-            self.nPresamples += 3
+    @property
+    def pulse_size_bytes(self):
+        return self.dtype.itemsize
 
-        # Record the sample times in microseconds
-        self.sample_usec = (np.arange(self.nSamples)-self.nPresamples) * self.timebase * 1e6
+    def reopen_binary(self, first_pulse: int = 0, max_pulses: Optional[int] = None) -> Self:
+        current_binary_size = os.path.getsize(self.filename) - self.header_size
+        full_npulses = current_binary_size // self.pulse_size_bytes
+        npulses = full_npulses - first_pulse
+        if max_pulses is not None:
+            npulses = min(max_pulses, npulses)
+        offset = self.header_size + first_pulse * self.pulse_size_bytes
+        mmap = np.memmap(self.filename, self.dtype, mode="r", offset=offset, shape=(npulses,))
+        return replace(self, _mmap=mmap, first_pulse=first_pulse, max_pulses=max_pulses, binary_size=current_binary_size)
 
-    def get_header_info_as_dict(self):
-        return {"number_of_columns": self.number_of_columns,
-                "number_of_rows": self.number_of_rows,
-                "timebase_s": self.timebase}
-
-    def __repr__(self):
-        return f"LJHFile {self.filename}"
-
-    def read_trace(self, i):
+    def read_trace(self, i) -> npt.ArrayLike:
         return self._mmap[i]["data"]
 
-    def to_polars(self, keep_posix_usec=False):
+    def to_polars(self, keep_posix_usec=False) -> Tuple[pl.DataFrame, pl.DataFrame]:
         df = pl.DataFrame({"pulse": self._mmap["data"],
                            "posix_usec": self._mmap["posix_usec"],
                            "rowcount": self._mmap["rowcount"]},
-                          schema={"pulse": pl.Array(pl.UInt16, self.nSamples),
+                          schema={"pulse": pl.Array(pl.UInt16, self.nsamples),
                                   "posix_usec": pl.UInt64,
                                   "rowcount": pl.UInt64})
         df = df.select(pl.from_epoch("posix_usec", time_unit="us").alias("timestamp")).with_columns(df)
         if not keep_posix_usec:
             df = df.select(pl.exclude("posix_usec"))
-        header_df = pl.DataFrame(self.header_dict)
+        header_df = pl.DataFrame(self.header)
         return df, header_df
 
-    def write_truncated_ljh(self, filename, nPulses):
+    def write_truncated_ljh(self, filename: str, npulses: int) -> None:
         with open(filename, "wb") as f:
-            f.write(self.header_str)
-            for i in range(nPulses):
+            f.write(self.header_string)
+            for i in range(npulses):
                 f.write(self._mmap[i].tobytes())

--- a/moss/noise_channel.py
+++ b/moss/noise_channel.py
@@ -96,7 +96,7 @@ class NoiseChannel:
 
     @classmethod
     def from_ljh(cls, path):
-        ljh = moss.LJHFile(path)
+        ljh = moss.LJHFile.open(path)
         df, header_df = ljh.to_polars()
         noise_channel = cls(df, header_df, header_df["Timebase"][0])
         return noise_channel

--- a/moss/test_multifit.py
+++ b/moss/test_multifit.py
@@ -1,70 +1,69 @@
 import moss
 import numpy as np
 import mass
-import pytest
-from pytest import approx
 import polars as pl
+
 
 def generate_and_fit_fake_data(
     n_mn_counts=2000,
     mn_fwhm_ev=4,
     n_gaussian_counts=1000,
-    gaussian_centers_ev=[2000,4000],
+    gaussian_centers_ev=[2000, 4000],
     gaussian_fwhm_ev=4,
     seed=1
 ):
     """
     Generate fake spectral data with MnKAlpha line and Gaussian peak, then fit with MultiFit.
     """
-    
+
     rng = np.random.default_rng(seed)
-    
+
     # Generate MnKAlpha line data
     line = mass.calibration.fluorescence_lines.MnKAlpha
     mn_values = line.rvs(size=n_mn_counts, instrument_gaussian_fwhm=mn_fwhm_ev, rng=rng)
-    
+
     gaussian_values = []
     for gaussian_center_ev in gaussian_centers_ev:
         # Generate Gaussian peak data
         gaussian_values.append(rng.normal(
-            loc=gaussian_center_ev, 
-            scale=gaussian_fwhm_ev / 2.3548, 
+            loc=gaussian_center_ev,
+            scale=gaussian_fwhm_ev / 2.3548,
             size=n_gaussian_counts
         ))
 
     # Combine all photon energies
     all_values = np.concatenate([mn_values, gaussian_values[0], gaussian_values[1]])
-    df = pl.DataFrame({"energy": all_values})   
-    ch = moss.Channel(df, header=moss.ChannelHeader(description="Fake spectral data for testing MultiFit", 
+    df = pl.DataFrame({"energy": all_values})
+    ch = moss.Channel(df, header=moss.ChannelHeader(description="Fake spectral data for testing MultiFit",
                                                     ch_num=1, frametime_s=0.1,
                                                     n_presamples=100, n_samples=100,
-                                                    df= None))
+                                                    df=None))
 
-    
     # Set up MultiFit
     multifit = (moss.MultiFit(
-        default_fit_width=80, 
+        default_fit_width=80,
         default_bin_size=1
     ).with_line("MnKAlpha")
-    .with_line(gaussian_centers_ev[0])
-    .with_line(gaussian_centers_ev[1])
+        .with_line(gaussian_centers_ev[0])
+        .with_line(gaussian_centers_ev[1])
     )
-    mass.line_models.VALIDATE_BIN_SIZE=False
+    mass.line_models.VALIDATE_BIN_SIZE = False
     ch = ch.rough_cal_combinatoric(["MnKAlpha", gaussian_centers_ev[0], gaussian_centers_ev[1]],
                                    ph_smoothing_fwhm=4, n_extra=1,
                                    uncalibrated_col="energy",
                                    calibrated_col="energy2")
-    ch = ch.multifit_mass_cal(multifit, 
-                            previous_cal_step_index=-1,
-                            calibrated_col="energy3")
-    
+    ch = ch.multifit_mass_cal(multifit,
+                              previous_cal_step_index=-1,
+                              calibrated_col="energy3")
 
     return ch
+
 
 def test_multifit_and_saving_and_loading_steps_in_channel():
     ch = generate_and_fit_fake_data()
     ch.step_plot(-1)
-    import tempfile, os
+    import tempfile
+    import os
     with tempfile.TemporaryDirectory() as tmpdir:        # cleaned up on exit
         filename = os.path.join(tmpdir, "steps.pkl")    # just a string path
         ch.save_steps(filename)
@@ -74,22 +73,23 @@ def test_multifit_and_saving_and_loading_steps_in_channel():
     plt.close()
     plt.close()
 
+
 def test_multifit_and_saving_and_loading_steps_in_channels():
     ch = generate_and_fit_fake_data()
     data = moss.Channels({ch.header.ch_num: ch}, "for test_multifit_in_channels")
-    import tempfile, os
+    import tempfile
+    import os
     with tempfile.TemporaryDirectory() as tmpdir:        # cleaned up on exit
         filename = os.path.join(tmpdir, "steps.pkl")    # just a string path
         data.save_steps(filename)
-        data2 = data.load_steps(filename) # it would be better to start with a data that doesn't have the output of the steps... 
+        _ = data.load_steps(filename)  # it would be better to start with a data that doesn't have the output of the steps...
         # and maybe throw an error for writing over existing columns?
         # fow now, I'm happy this is tested at all
         steps = moss.misc.unpickle_object(filename)
-    data3 = data.with_steps_dict(steps) # pretty much the blow by blow version of load_steps
+    _ = data.with_steps_dict(steps)  # pretty much the blow by blow version of load_steps
 
- 
 
 if __name__ == "__main__":
     # Run the function to generate and fit fake data
-    test_multifit_in_channel()
-    test_multifit_in_channels()
+    test_multifit_and_saving_and_loading_steps_in_channel()
+    test_multifit_and_saving_and_loading_steps_in_channels()

--- a/moss/test_stuff.py
+++ b/moss/test_stuff.py
@@ -23,16 +23,18 @@ def test_ljh_fractional_record(tmp_path):
     # half of the next record. Check that the resulting file can be opened.
     npulses = 10
     p = pulsedata.pulse_noise_ljh_pairs["20230626"]
-    ljh = moss.LJHFile(p.pulse_folder/"20230626_run0001_chan4102.ljh")
+    ljh = moss.LJHFile(p.pulse_folder / "20230626_run0001_chan4102.ljh")
     assert ljh.nPulses > npulses
-    binary_size = (npulses + 0.5) * ljh.pulse_size_bytes
-    total_size = int(binary_size) + ljh.header_size
+    binary_size1 = int((npulses + 0.5) * ljh.pulse_size_bytes)
+    binary_size2 = (2*npulses) * ljh.pulse_size_bytes
+    total_size1 = binary_size1 + ljh.header_size
 
     input_file_path = ljh.filename
     ragged_ljh_file_path = tmp_path / "test_file.ljh"
 
     with open(input_file_path, 'rb') as source_file:
-        data_to_copy = source_file.read(total_size)
+        data_to_copy = source_file.read(total_size1)
+        data_to_save = source_file.read(binary_size2 - binary_size1)
     with open(ragged_ljh_file_path, 'wb') as destination_file:
         destination_file.write(data_to_copy)
 
@@ -40,6 +42,13 @@ def test_ljh_fractional_record(tmp_path):
     assert ljh2.nPulses == npulses
     assert ljh2.header_size == ljh.header_size
     assert ljh2.pulse_size_bytes * ljh2.nPulses + ljh2.header_size < os.path.getsize(ragged_ljh_file_path)
+
+    with open(ragged_ljh_file_path, 'ab') as destination_file:
+        destination_file.write(data_to_save)
+    ljh2.reopen_binary(npulses)
+    assert ljh2.nPulses == npulses
+    assert ljh2.header_size == ljh.header_size
+    assert ljh2.pulse_size_bytes * 2 * ljh2.nPulses + ljh2.header_size == os.path.getsize(ragged_ljh_file_path)
 
 
 def test_follow_mass_filtering_rst():

--- a/moss/test_stuff.py
+++ b/moss/test_stuff.py
@@ -42,13 +42,20 @@ def test_ljh_fractional_record(tmp_path):
     assert ljh2.nPulses == npulses
     assert ljh2.header_size == ljh.header_size
     assert ljh2.pulse_size_bytes * ljh2.nPulses + ljh2.header_size < os.path.getsize(ragged_ljh_file_path)
+    for i in range(npulses):
+        assert np.all(ljh2.read_trace(i) == ljh.read_trace(i))
 
+    # Now extend the file to contain 2*npulses binary records
     with open(ragged_ljh_file_path, 'ab') as destination_file:
         destination_file.write(data_to_save)
+
+    # Reopen it, skipping the first `npulses` records. Test that it works .
     ljh2.reopen_binary(npulses)
     assert ljh2.nPulses == npulses
     assert ljh2.header_size == ljh.header_size
     assert ljh2.pulse_size_bytes * 2 * ljh2.nPulses + ljh2.header_size == os.path.getsize(ragged_ljh_file_path)
+    for i in range(npulses):
+        assert np.all(ljh2.read_trace(i) == ljh.read_trace(i + npulses))
 
 
 def test_follow_mass_filtering_rst():

--- a/moss/test_stuff.py
+++ b/moss/test_stuff.py
@@ -7,9 +7,9 @@ import pytest
 
 def test_ljh_to_polars():
     p = pulsedata.pulse_noise_ljh_pairs["20230626"]
-    ljh_noise = moss.LJHFile(p.noise_folder/"20230626_run0000_chan4102.ljh")
+    ljh_noise = moss.LJHFile.open(p.noise_folder/"20230626_run0000_chan4102.ljh")
     df_noise, header_df_noise = ljh_noise.to_polars()
-    ljh = moss.LJHFile(p.pulse_folder/"20230626_run0001_chan4102.ljh")
+    ljh = moss.LJHFile.open(p.pulse_folder/"20230626_run0001_chan4102.ljh")
     df, header_df = ljh.to_polars()
 
 
@@ -23,8 +23,8 @@ def test_ljh_fractional_record(tmp_path):
     # half of the next record. Check that the resulting file can be opened.
     npulses = 10
     p = pulsedata.pulse_noise_ljh_pairs["20230626"]
-    ljh = moss.LJHFile(p.pulse_folder / "20230626_run0001_chan4102.ljh")
-    assert ljh.nPulses > npulses
+    ljh = moss.LJHFile.open(p.pulse_folder / "20230626_run0001_chan4102.ljh")
+    assert ljh.npulses > npulses
     binary_size1 = int((npulses + 0.5) * ljh.pulse_size_bytes)
     binary_size2 = (2*npulses) * ljh.pulse_size_bytes
     total_size1 = binary_size1 + ljh.header_size
@@ -38,10 +38,10 @@ def test_ljh_fractional_record(tmp_path):
     with open(ragged_ljh_file_path, 'wb') as destination_file:
         destination_file.write(data_to_copy)
 
-    ljh2 = moss.LJHFile(ragged_ljh_file_path)
-    assert ljh2.nPulses == npulses
+    ljh2 = moss.LJHFile.open(ragged_ljh_file_path)
+    assert ljh2.npulses == npulses
     assert ljh2.header_size == ljh.header_size
-    assert ljh2.pulse_size_bytes * ljh2.nPulses + ljh2.header_size < os.path.getsize(ragged_ljh_file_path)
+    assert ljh2.pulse_size_bytes * ljh2.npulses + ljh2.header_size < os.path.getsize(ragged_ljh_file_path)
     for i in range(npulses):
         assert np.all(ljh2.read_trace(i) == ljh.read_trace(i))
 
@@ -50,10 +50,10 @@ def test_ljh_fractional_record(tmp_path):
         destination_file.write(data_to_save)
 
     # Reopen it, skipping the first `npulses` records. Test that it works .
-    ljh2.reopen_binary(npulses)
-    assert ljh2.nPulses == npulses
+    ljh2 = ljh2.reopen_binary(npulses)
+    assert ljh2.npulses == npulses
     assert ljh2.header_size == ljh.header_size
-    assert ljh2.pulse_size_bytes * 2 * ljh2.nPulses + ljh2.header_size == os.path.getsize(ragged_ljh_file_path)
+    assert ljh2.pulse_size_bytes * 2 * ljh2.npulses + ljh2.header_size == os.path.getsize(ragged_ljh_file_path)
     for i in range(npulses):
         assert np.all(ljh2.read_trace(i) == ljh.read_trace(i + npulses))
 

--- a/moss/test_stuff.py
+++ b/moss/test_stuff.py
@@ -21,10 +21,11 @@ def test_ljh_fractional_record(tmp_path):
 
     # Specifically, copy the LJH file through the first `npulses` binary records, plus exactly
     # half of the next record. Check that the resulting file can be opened.
+    # Then later add enough raw data to have `2*npulses` records. Make sure it can be re-opened.
     npulses = 10
     p = pulsedata.pulse_noise_ljh_pairs["20230626"]
     ljh = moss.LJHFile.open(p.pulse_folder / "20230626_run0001_chan4102.ljh")
-    assert ljh.npulses > npulses
+    assert ljh.npulses >= 2 * npulses
     binary_size1 = int((npulses + 0.5) * ljh.pulse_size_bytes)
     binary_size2 = (2*npulses) * ljh.pulse_size_bytes
     total_size1 = binary_size1 + ljh.header_size
@@ -33,10 +34,10 @@ def test_ljh_fractional_record(tmp_path):
     ragged_ljh_file_path = tmp_path / "test_file.ljh"
 
     with open(input_file_path, 'rb') as source_file:
-        data_to_copy = source_file.read(total_size1)
-        data_to_save = source_file.read(binary_size2 - binary_size1)
+        data_to_copy_initially = source_file.read(total_size1)
+        data_to_append_later = source_file.read(binary_size2 - binary_size1)
     with open(ragged_ljh_file_path, 'wb') as destination_file:
-        destination_file.write(data_to_copy)
+        destination_file.write(data_to_copy_initially)
 
     ljh2 = moss.LJHFile.open(ragged_ljh_file_path)
     assert ljh2.npulses == npulses
@@ -47,15 +48,15 @@ def test_ljh_fractional_record(tmp_path):
 
     # Now extend the file to contain 2*npulses binary records
     with open(ragged_ljh_file_path, 'ab') as destination_file:
-        destination_file.write(data_to_save)
+        destination_file.write(data_to_append_later)
 
-    # Reopen it, skipping the first `npulses` records. Test that it works .
-    ljh2 = ljh2.reopen_binary(npulses)
-    assert ljh2.npulses == npulses
-    assert ljh2.header_size == ljh.header_size
-    assert ljh2.pulse_size_bytes * 2 * ljh2.npulses + ljh2.header_size == os.path.getsize(ragged_ljh_file_path)
+    # Reopen it.
+    ljh3 = ljh2.reopen_binary()
+    assert ljh3.npulses == 2 * npulses
+    assert ljh3.header_size == ljh.header_size
+    assert ljh3.pulse_size_bytes * ljh3.npulses + ljh3.header_size == os.path.getsize(ragged_ljh_file_path)
     for i in range(npulses):
-        assert np.all(ljh2.read_trace(i) == ljh.read_trace(i + npulses))
+        assert np.all(ljh3.read_trace(i) == ljh.read_trace(i))
 
 
 def test_follow_mass_filtering_rst():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,8 @@ testpaths = [
     "moss",
     "examples"
 ]
+
+# Excludes all .py files within the 'examples' directory, because these are all
+# marimo notebooks and don't follow the usual Python style.
+[tool.ruff]
+extend-exclude = ["examples/*.py"]


### PR DESCRIPTION
This demonstrates how we might write the `LJHFile` as a frozen dataclass. Use `LJHFile.open(filename)` instead of the previous `LJHFile(filename)` to construct new instances.