### PR TITLE
add argument exclude_ch_nums to Channels.from_ljh_folders

### DIFF
--- a/moss/channels.py
+++ b/moss/channels.py
@@ -207,7 +207,8 @@ class Channels:
         return cls(channels, description)
 
     @classmethod
-    def from_ljh_folder(cls, pulse_folder, noise_folder=None, limit=None):
+    def from_ljh_folder(cls, pulse_folder, noise_folder=None, limit=None, exclude_ch_nums=[]):
+        # exclude_ch_nums is a list of channel numbers to exclude
         import os
         assert os.path.isdir(pulse_folder), f"{pulse_folder=} {noise_folder=}"
         if noise_folder is None:
@@ -215,7 +216,7 @@ class Channels:
             pairs = [(path, None) for path in paths]
         else:
             assert os.path.isdir(noise_folder), f"{pulse_folder=} {noise_folder=}"
-            pairs = moss.ljhutil.match_files_by_channel(pulse_folder, noise_folder, limit=limit)
+            pairs = moss.ljhutil.match_files_by_channel(pulse_folder, noise_folder, limit=limit, exclude_ch_nums=exclude_ch_nums)
         description = f"from_ljh_folder {pulse_folder=} {noise_folder=}"
         print(f"{description}")
         print(f"in from_ljh_folder has {len(pairs)} pairs")

--- a/moss/ljhutil.py
+++ b/moss/ljhutil.py
@@ -71,7 +71,7 @@ def extract_channel_number(file_path: str) -> int:
         raise ValueError(f"File path does not match expected pattern: {file_path}")
 
 
-def match_files_by_channel(folder1: str, folder2: str, limit=None) -> List[Iterator[Tuple[str, str]]]:
+def match_files_by_channel(folder1: str, folder2: str, limit=None, exclude_ch_nums=[]) -> List[Iterator[Tuple[str, str]]]:
     """
     Matches .ljh files from two folders by channel number.
 
@@ -106,7 +106,7 @@ def match_files_by_channel(folder1: str, folder2: str, limit=None) -> List[Itera
 
     matching_pairs = []
     for channel in sorted(files1_by_channel.keys()):
-        if channel in files2_by_channel.keys():
+        if channel in files2_by_channel.keys() and channel not in exclude_ch_nums:
             matching_pairs.append((files1_by_channel[channel], files2_by_channel[channel]))
     # print(f"in match_files_by_channel found {len(matching_pairs)} channel pairs, {limit=}")
     matching_pairs_limited = matching_pairs[:limit]


### PR DESCRIPTION
add a list `exclude_ch_nums` to `fom_ljh_folders` to easily exclude annoying ch_nums on load